### PR TITLE
Bump http-sync version and add info about SauceLabs

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,18 @@ var driver = new WebDriver('http://127.0.0.1:4444/wd/hub', desiredCapabilities);
 driver.navigateTo('http://www.google.com');
 ```
 
+### Sauce Labs
+
+You can use this library with SauceLabs or any another browser service with authorization. Just add your credentials into URL:
+
+```javascript
+var WebDriver = require('webdriver-http-sync');
+var desiredCapabilities = {browserName: 'firefox'};
+
+var driver = new WebDriver('http://SAUCE_USERNAME:SAUCE_API_KEY@ondemand.saucelabs.com:4444/wd/hub', desiredCapabilities);
+driver.navigateTo('http://www.google.com');
+```
+
 Method | Description
 :----- | :----------
 `driver.navigateTo(url)` | Navigates the browser to the specificed relative or absolute url. If relative, the root is assumed to be `http://127.0.0.1:#{applicationPort}`, where `applicationPort` is passed in to the options for `testium.runTests`.

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "coffee-script": "^1.9.0",
     "concat-stream": "^1.4.7",
     "debug": "^2.1.1",
-    "http-sync": "~0.1.1",
+    "http-sync": "~0.1.2",
     "lodash": "^3.1.0"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
   "main": "lib/index.js",
   "dependencies": {
     "assertive": "^1.4.0",
-    "coffee-script": "^1.9.0",
+    "coffee-script": "1.9.1",
     "concat-stream": "^1.4.7",
     "debug": "^2.1.1",
     "http-sync": "~0.1.2",


### PR DESCRIPTION
Since this http-sync has authorisation support (see https://github.com/dhruvbird/http-sync/pull/40), it is possible to use your webdriver client with SauceLabs service.

I've added a usage example into docs. This worked for me.