### PR TITLE
capture stack trace for failed tryParse

### DIFF
--- a/lib/json.js
+++ b/lib/json.js
@@ -38,6 +38,7 @@ module.exports.tryParse = function(jsonString) {
   } catch (_error) {
     error = _error;
     error.message = "Unable to parse JSON: " + error.message + "\nAttempted to parse: " + jsonString;
+    Error.captureStackTrace(error);
     throw error;
   }
 };

--- a/src/json.coffee
+++ b/src/json.coffee
@@ -35,5 +35,7 @@ module.exports.tryParse = (jsonString) ->
     return JSON.parse jsonString
   catch error
     error.message = "Unable to parse JSON: #{error.message}\nAttempted to parse: #{jsonString}"
+    # creating a stack trace because it wasn't created on rare occasions
+    Error.captureStackTrace error
     throw error
 


### PR DESCRIPTION
I was working on integration tests for a large-ish app and got a "JSON: Unexpected end of input" error, but no stack trace.

It took me longer than I wanted to track it down to webdriver-http-sync, but for reasons still beyond me (i.e. I can't reproduce it in a small setting yet), err.stack wasn't supplied.

The only text I get in the terminal:

```
Uncaught SyntaxError: Unable to parse JSON: Unexpected end of input
Attempted to parse:
```

With this change, I also get `at Object.module.exports.tryParse (/home/.../json.js:9:11)`, etc. etc., which would've probably shaved an hour of traipsing through testium, mocha, etc.