### PR TITLE
Revert "capture stack trace for failed tryParse"

### DIFF
--- a/lib/json.js
+++ b/lib/json.js
@@ -38,7 +38,6 @@ module.exports.tryParse = function(jsonString) {
   } catch (_error) {
     error = _error;
     error.message = "Unable to parse JSON: " + error.message + "\nAttempted to parse: " + jsonString;
-    Error.captureStackTrace(error);
     throw error;
   }
 };

--- a/src/json.coffee
+++ b/src/json.coffee
@@ -35,7 +35,5 @@ module.exports.tryParse = (jsonString) ->
     return JSON.parse jsonString
   catch error
     error.message = "Unable to parse JSON: #{error.message}\nAttempted to parse: #{jsonString}"
-    # creating a stack trace because it wasn't created on rare occasions
-    Error.captureStackTrace error
     throw error
 


### PR DESCRIPTION
This reverts commit ee541465386ddcb4cd6e6fcf2cf5365cae8174dd.

As per https://github.com/groupon/webdriver-http-sync/pull/32#issuecomment-146402110