### PR TITLE
Consistently fail on PhantomJS errors

### DIFF
--- a/lib/cookie_api.js
+++ b/lib/cookie_api.js
@@ -52,6 +52,9 @@ module.exports = function(http) {
     },
     clearCookies: function() {
       http["delete"]("/cookie");
+    },
+    clearCookie: function(name) {
+      http["delete"]("/cookie/" + (encodeURIComponent(name)));
     }
   };
 };

--- a/lib/element.js
+++ b/lib/element.js
@@ -31,7 +31,7 @@ LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
 NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
 SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
-var Element, assert, createElement, createElements, http, inspect, json, parseElement, parseResponseData,
+var Element, NOT_FOUND_MESSAGE, assert, createElement, createElements, elementOrNull, http, inspect, json, parseElement, parseResponseData,
   slice = [].slice;
 
 http = require('./http');
@@ -43,6 +43,8 @@ json = require('./json');
 parseResponseData = require('./parse_response');
 
 inspect = require('util').inspect;
+
+NOT_FOUND_MESSAGE = new RegExp(['Unable to locate element', 'Unable to find element', 'no such element'].join('|'));
 
 createElement = function(http, selector, root) {
   var response;
@@ -98,7 +100,11 @@ module.exports = Element = (function() {
   };
 
   Element.prototype.getElement = function(selector) {
-    return createElement(this.http, selector, this.root);
+    return elementOrNull((function(_this) {
+      return function() {
+        return createElement(_this.http, selector, _this.root);
+      };
+    })(this));
   };
 
   Element.prototype.getElements = function(selector) {
@@ -150,3 +156,17 @@ module.exports = Element = (function() {
   return Element;
 
 })();
+
+elementOrNull = Element.elementOrNull = function(create) {
+  var error;
+  try {
+    return create();
+  } catch (_error) {
+    error = _error;
+    if (NOT_FOUND_MESSAGE.test(error.toString())) {
+      return null;
+    }
+    console.error(error.toString());
+    throw error;
+  }
+};

--- a/lib/element_api.js
+++ b/lib/element_api.js
@@ -31,11 +31,11 @@ LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
 NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
 SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
-var Element, createElement, createElements, parseElement, parseResponseData;
+var Element, createElement, createElements, elementOrNull, parseElement, parseResponseData;
 
 parseResponseData = require('./parse_response');
 
-Element = require('./element');
+elementOrNull = (Element = require('./element')).elementOrNull;
 
 createElement = function(http, selector) {
   var response;
@@ -72,7 +72,9 @@ parseElement = function(http, elementId) {
 module.exports = function(http) {
   return {
     getElement: function(selector) {
-      return createElement(http, selector);
+      return elementOrNull(function() {
+        return createElement(http, selector);
+      });
     },
     getElements: function(selector) {
       return createElements(http, selector);

--- a/lib/parse_response.js
+++ b/lib/parse_response.js
@@ -31,7 +31,7 @@ LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
 NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
 SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
-var cleanResponse, json, validateResponse;
+var cleanResponse, createDetailError, json, validateResponse;
 
 json = require('./json');
 
@@ -41,12 +41,30 @@ cleanResponse = function(response) {
   return delete response["class"];
 };
 
+createDetailError = function(message) {
+  var detailError, details, key, value;
+  if (message[0] === '{') {
+    details = json.tryParse(message);
+    if (typeof (details != null ? details.errorMessage : void 0) === 'string') {
+      detailError = new Error(details.errorMessage);
+      for (key in details) {
+        value = details[key];
+        if (key !== 'errorMessage') {
+          detailError[key] = value;
+        }
+      }
+      return detailError;
+    }
+  }
+  return new Error(message);
+};
+
 validateResponse = function(response) {
   var friendlyError;
-  if ((response.message == null) || (response.stackTrace == null)) {
+  if (response.message == null) {
     return;
   }
-  friendlyError = new Error(response.message);
+  friendlyError = createDetailError(response.message);
   friendlyError.inner = response;
   throw friendlyError;
 };

--- a/src/cookie_api.coffee
+++ b/src/cookie_api.coffee
@@ -47,3 +47,6 @@ module.exports = (http) ->
     http.delete "/cookie"
     return
 
+  clearCookie: (name) ->
+    http.delete "/cookie/#{encodeURIComponent name}"
+    return

--- a/src/element_api.coffee
+++ b/src/element_api.coffee
@@ -31,7 +31,7 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 ###
 
 parseResponseData = require './parse_response'
-Element = require './element'
+{elementOrNull} = Element = require './element'
 
 createElement = (http, selector) ->
   response = http.post "/element",
@@ -56,7 +56,8 @@ parseElement = (http, elementId) ->
 
 module.exports = (http) ->
   getElement: (selector) ->
-    createElement http, selector
+    elementOrNull ->
+      createElement http, selector
 
   getElements: (selector) ->
     createElements http, selector

--- a/src/parse_response.coffee
+++ b/src/parse_response.coffee
@@ -37,10 +37,23 @@ cleanResponse = (response) ->
   delete response.hCode # unhelpful selenium noise
   delete response.class # unhelpful selenium noise
 
-validateResponse = (response) ->
-  return if !response.message? || !response.stackTrace?
+createDetailError = (message) ->
+  if message[0] == '{'
+    details = json.tryParse message
+    if typeof details?.errorMessage == 'string'
+      detailError = new Error details.errorMessage
 
-  friendlyError = new Error response.message
+      for key, value of details
+        detailError[key] = value if key != 'errorMessage'
+
+      return detailError
+
+  new Error message
+
+validateResponse = (response) ->
+  return unless response.message?
+
+  friendlyError = createDetailError response.message
   friendlyError.inner = response
   throw friendlyError
 


### PR DESCRIPTION
Not all errors phantomjs returns contain a `stackTrace`. The consequence is that they were silently ignored up to now. This had multiple consequences:

* When switching to invalid frame ids, it was silently ignoring it
* When requesting non-existent DOM elements (or anything else went wrong during `getElement`), it was silently ignoring it
* When trying to set a cookie on the wrong domain, it was silently ignoring it

This fixes the error parsing to catch those and also introduces changes required to not trigger the error conditions.

See: https://github.com/testiumjs/testium-driver-sync/pull/6