### PR TITLE
Warn only for non-critical errors

### DIFF
--- a/lib/parse_response.js
+++ b/lib/parse_response.js
@@ -31,7 +31,11 @@ LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
 NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
 SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
-var cleanResponse, createDetailError, json, validateResponse;
+var cleanResponse, createDetailError, debug, json, logWarning, omit, validateResponse;
+
+omit = require('lodash').omit;
+
+debug = require('debug')('webdriver-http-sync:parse_response');
 
 json = require('./json');
 
@@ -59,10 +63,27 @@ createDetailError = function(message) {
   return new Error(message);
 };
 
+logWarning = function(message) {
+  var details;
+  if (message[0] === '{') {
+    details = json.tryParse(message);
+    if (typeof (details != null ? details.errorMessage : void 0) === 'string') {
+      return debug(details.errorMessage, omit(details, 'errorMessage'));
+    } else {
+      return debug(details);
+    }
+  } else {
+    return debug(message);
+  }
+};
+
 validateResponse = function(response) {
   var friendlyError;
   if (response.message == null) {
     return;
+  }
+  if (response.stackTrace == null) {
+    return logWarning(response.message);
   }
   friendlyError = createDetailError(response.message);
   friendlyError.inner = response;

--- a/src/parse_response.coffee
+++ b/src/parse_response.coffee
@@ -30,6 +30,9 @@ NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
 SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 ###
 
+{omit} = require 'lodash'
+debug = require('debug')('webdriver-http-sync:parse_response')
+
 json = require './json'
 
 cleanResponse = (response) ->
@@ -50,8 +53,20 @@ createDetailError = (message) ->
 
   new Error message
 
+logWarning = (message) ->
+  if message[0] == '{'
+    details = json.tryParse message
+    if typeof details?.errorMessage == 'string'
+      debug details.errorMessage, omit(details, 'errorMessage')
+    else
+      debug details
+  else
+    debug message
+
 validateResponse = (response) ->
   return unless response.message?
+
+  return logWarning(response.message) unless response.stackTrace?
 
   friendlyError = createDetailError response.message
   friendlyError.inner = response


### PR DESCRIPTION
There are multiple places that can potential throw now, including things like `.isVisible()` for a DOM element that got removed from the DOM. The latter makes `.waitForElementVisible` unsafe because during navigation `getElement(".foo")` might return an element that gets removed before `.isVisible` is called. I'm expecting more of these edge cases and while we *should* be fixing those, there's no value in making people's test suites fail in the meantime.