### PR TITLE
feat: add support for buttondown/up & moveto

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,6 +81,8 @@ Method | Description
 `driver.typeAlert(text)` | Send `text` to the visable alert's input box.
 `driver.getGeolocation()` | Returns the browser's HTML5 geolocation. Ex: `{latitude: 37.425, longitude: -122.136, altitude: 10.0}`. Not supported in all browsers.
 `driver.setGeolocation(location)` | Set the browser's HTML5 geolocation. Expects `location` to be an object like `{latitude: 37.425, longitude: -122.136, altitude: 10.0}`. Not supported in all browsers.
+`driver.buttonDown(button)` | Presses down the pointer button (default 0 = left, can be 1 = middle, 2 = right) at location of last `element.movePointerRelativeTo()`
+`driver.buttonUp(button)` | Like `driver.buttonDown()`
 `driver.close()` | Closes the WebDriver session.
 
 ### Element
@@ -99,6 +101,7 @@ Method | Description
 `element.type(strings...)` | Sends `strings...` to the input element.
 `element.clear()` | Clears the input element.
 `element.click()` | Calls click on the element.
+`element.movePointerRelativeTo(xOffset, yOffset)` | Moves the pointer to the coordinates given, relative to this element (default centered)
 
 ## Contributing
 
@@ -108,100 +111,104 @@ The most important and often used methods are already implemented. You can help 
 
 Status | HTTP Method | Path  | Summary
 :-----:| ----------- | ----- | -------
-![Not Yet Implemented](./docs/not_implemented.png "Not Yet Implemented") | GET | `/status` | Query the server's current status.
-![Implemented](./docs/implemented.png "Implemented") | POST | `/session` | Create a new session.
-![Not Yet Implemented](./docs/not_implemented.png "Not Yet Implemented") | GET | `/sessions` | Returns a list of the currently active sessions.
-![Not Yet Implemented](./docs/not_implemented.png "Not Yet Implemented") | GET | `/session/:sessionId` | Retrieve the capabilities of the specified session.
-![Implemented](./docs/implemented.png "Implemented") | DELETE | `/session/:sessionId` | Delete the session.
-![Implemented](./docs/implemented.png "Implemented") | POST | `/session/:sessionId/timeouts` |  Configure the amount of time that a particular type of operation can execute for before they are aborted and a `Timeout` error is returned to the client.
-![Implemented](./docs/implemented.png "Implemented") | POST | `/session/:sessionId/timeouts/async_script` | Set the amount of time, in milliseconds, that asynchronous scripts executed by `/session/:sessionId/execute_async` are permitted to run before they are aborted and a `Timeout` error is returned to the client.
-![Implemented](./docs/implemented.png "Implemented") | POST | `/session/:sessionId/timeouts/implicit_wait` |  Set the amount of time the driver should wait when searching for elements.
-![Implemented](./docs/implemented.png "Implemented") | GET | `/session/:sessionId/window_handle` | Retrieve the current window handle.
-![Not Yet Implemented](./docs/not_implemented.png "Not Yet Implemented") | GET | `/session/:sessionId/window_handles` |  Retrieve the list of all window handles available to the session.
-![Implemented](./docs/implemented.png "Implemented") | GET | `/session/:sessionId/url` | Retrieve the URL of the current page.
-![Implemented](./docs/implemented.png "Implemented") | POST | `/session/:sessionId/url` | Navigate to a new URL.
-![Not Yet Implemented](./docs/not_implemented.png "Not Yet Implemented") | POST | `/session/:sessionId/forward` | Navigate forwards in the browser history, if possible.
-![Not Yet Implemented](./docs/not_implemented.png "Not Yet Implemented") | POST | `/session/:sessionId/back` |  Navigate backwards in the browser history, if possible.
-![Not Yet Implemented](./docs/not_implemented.png "Not Yet Implemented") | POST | `/session/:sessionId/refresh` | Refresh the current page.
-![Implemented](./docs/implemented.png "Implemented") | POST | `/session/:sessionId/execute` | Inject a snippet of JavaScript into the page for execution in the context of the currently selected frame.
-![Implemented](./docs/implemented.png "Implemented") | POST | `/session/:sessionId/execute_async` | Inject a snippet of JavaScript into the page for execution in the context of the currently selected frame.
-![Implemented](./docs/implemented.png "Implemented") | GET | `/session/:sessionId/screenshot` |  Take a screenshot of the current page.
-![Not Yet Implemented](./docs/not_implemented.png "Not Yet Implemented") | GET | `/session/:sessionId/ime/available_engines` | List all available engines on the machine.
-![Not Yet Implemented](./docs/not_implemented.png "Not Yet Implemented") | GET | `/session/:sessionId/ime/active_engine` | Get the name of the active IME engine.
-![Not Yet Implemented](./docs/not_implemented.png "Not Yet Implemented") | GET | `/session/:sessionId/ime/activated` | Indicates whether IME input is active at the moment (not if it's available.
-![Not Yet Implemented](./docs/not_implemented.png "Not Yet Implemented") | POST | `/session/:sessionId/ime/deactivate` |  De-activates the currently-active IME engine.
-![Not Yet Implemented](./docs/not_implemented.png "Not Yet Implemented") | POST | `/session/:sessionId/ime/activate` |  Make an engines that is available (appears on the listreturned by getAvailableEngines) active.
-![Implemented](./docs/implemented.png "Implemented") | POST | `/session/:sessionId/frame` | Change focus to another frame on the page.
-![Implemented](./docs/implemented.png "Implemented") | POST | `/session/:sessionId/window` |  Change focus to another window.
-![Implemented](./docs/implemented.png "Implemented") | DELETE | `/session/:sessionId/window` |  Close the current window.
-![Not Yet Implemented](./docs/not_implemented.png "Not Yet Implemented") | POST | `/session/:sessionId/window/:windowHandle/size` | Change the size of the specified window.
-![Not Yet Implemented](./docs/not_implemented.png "Not Yet Implemented") | GET | `/session/:sessionId/window/:windowHandle/size` | Get the size of the specified window.
-![Not Yet Implemented](./docs/not_implemented.png "Not Yet Implemented") | POST | `/session/:sessionId/window/:windowHandle/position` | Change the position of the specified window.
-![Not Yet Implemented](./docs/not_implemented.png "Not Yet Implemented") | GET | `/session/:sessionId/window/:windowHandle/position` | Get the position of the specified window.
-![Not Yet Implemented](./docs/not_implemented.png "Not Yet Implemented") | POST | `/session/:sessionId/window/:windowHandle/maximize` | Maximize the specified window if not already maximized.
-![Implemented](./docs/implemented.png "Implemented") | GET | `/session/:sessionId/cookie` |  Retrieve all cookies visible to the current page.
-![Implemented](./docs/implemented.png "Implemented") | POST | `/session/:sessionId/cookie` |  Set a cookie.
-![Implemented](./docs/implemented.png "Implemented") | DELETE | `/session/:sessionId/cookie` |  Delete all cookies visible to the current page.
-![Not Yet Implemented](./docs/not_implemented.png "Not Yet Implemented") | DELETE | `/session/:sessionId/cookie/:name` |  Delete the cookie with the given name.
-![Implemented](./docs/implemented.png "Implemented") | GET | `/session/:sessionId/source` |  Get the current page source.
-![Implemented](./docs/implemented.png "Implemented") | GET | `/session/:sessionId/title` | Get the current page title.
+![not-yet] | GET | `/status` | Query the server's current status.
+![impl] | POST | `/session` | Create a new session.
+![not-yet] | GET | `/sessions` | Returns a list of the currently active sessions.
+![not-yet] | GET | `/session/:sessionId` | Retrieve the capabilities of the specified session.
+![impl] | DELETE | `/session/:sessionId` | Delete the session.
+![impl] | POST | `/session/:sessionId/timeouts` |  Configure the amount of time that a particular type of operation can execute for before they are aborted and a `Timeout` error is returned to the client.
+![impl] | POST | `/session/:sessionId/timeouts/async_script` | Set the amount of time, in milliseconds, that asynchronous scripts executed by `/session/:sessionId/execute_async` are permitted to run before they are aborted and a `Timeout` error is returned to the client.
+![impl] | POST | `/session/:sessionId/timeouts/implicit_wait` |  Set the amount of time the driver should wait when searching for elements.
+![impl] | GET | `/session/:sessionId/window_handle` | Retrieve the current window handle.
+![not-yet] | GET | `/session/:sessionId/window_handles` |  Retrieve the list of all window handles available to the session.
+![impl] | GET | `/session/:sessionId/url` | Retrieve the URL of the current page.
+![impl] | POST | `/session/:sessionId/url` | Navigate to a new URL.
+![not-yet] | POST | `/session/:sessionId/forward` | Navigate forwards in the browser history, if possible.
+![not-yet] | POST | `/session/:sessionId/back` |  Navigate backwards in the browser history, if possible.
+![not-yet] | POST | `/session/:sessionId/refresh` | Refresh the current page.
+![impl] | POST | `/session/:sessionId/execute` | Inject a snippet of JavaScript into the page for execution in the context of the currently selected frame.
+![impl] | POST | `/session/:sessionId/execute_async` | Inject a snippet of JavaScript into the page for execution in the context of the currently selected frame.
+![impl] | GET | `/session/:sessionId/screenshot` |  Take a screenshot of the current page.
+![not-yet] | GET | `/session/:sessionId/ime/available_engines` | List all available engines on the machine.
+![not-yet] | GET | `/session/:sessionId/ime/active_engine` | Get the name of the active IME engine.
+![not-yet] | GET | `/session/:sessionId/ime/activated` | Indicates whether IME input is active at the moment (not if it's available.
+![not-yet] | POST | `/session/:sessionId/ime/deactivate` |  De-activates the currently-active IME engine.
+![not-yet] | POST | `/session/:sessionId/ime/activate` |  Make an engines that is available (appears on the listreturned by getAvailableEngines) active.
+![impl] | POST | `/session/:sessionId/frame` | Change focus to another frame on the page.
+![impl] | POST | `/session/:sessionId/window` |  Change focus to another window.
+![impl] | DELETE | `/session/:sessionId/window` |  Close the current window.
+![not-yet] | POST | `/session/:sessionId/window/:windowHandle/size` | Change the size of the specified window.
+![not-yet] | GET | `/session/:sessionId/window/:windowHandle/size` | Get the size of the specified window.
+![not-yet] | POST | `/session/:sessionId/window/:windowHandle/position` | Change the position of the specified window.
+![not-yet] | GET | `/session/:sessionId/window/:windowHandle/position` | Get the position of the specified window.
+![not-yet] | POST | `/session/:sessionId/window/:windowHandle/maximize` | Maximize the specified window if not already maximized.
+![impl] | GET | `/session/:sessionId/cookie` |  Retrieve all cookies visible to the current page.
+![impl] | POST | `/session/:sessionId/cookie` |  Set a cookie.
+![impl] | DELETE | `/session/:sessionId/cookie` |  Delete all cookies visible to the current page.
+![not-yet] | DELETE | `/session/:sessionId/cookie/:name` |  Delete the cookie with the given name.
+![impl] | GET | `/session/:sessionId/source` |  Get the current page source.
+![impl] | GET | `/session/:sessionId/title` | Get the current page title.
 ![Partially Implemented](./docs/partially_implemented.png "Can only find via CSS selector") | POST | `/session/:sessionId/element` | Search for an element on the page with a CSS selector, starting from the document root.
 ![Partially Implemented](./docs/partially_implemented.png "Can only find via CSS selector") | POST | `/session/:sessionId/elements` | Search for multiple elements on the page with a CSS selector, starting from the document root.
-![Not Yet Implemented](./docs/not_implemented.png "Not Yet Implemented") | POST | `/session/:sessionId/element/active` |  Get the element on the page that currently has focus.
-![Not Yet Implemented](./docs/not_implemented.png "Not Yet Implemented") | GET | `/session/:sessionId/element/:id` | Describe the identified element.
+![not-yet] | POST | `/session/:sessionId/element/active` |  Get the element on the page that currently has focus.
+![not-yet] | GET | `/session/:sessionId/element/:id` | Describe the identified element.
 ![Partially Implemented](./docs/partially_implemented.png "Can only find via CSS selector") | POST | `/session/:sessionId/element/:id/element` | Search for an element on the page, starting from the identified element.
 ![Partially Implemented](./docs/partially_implemented.png "Can only find via CSS selector") | POST | `/session/:sessionId/element/:id/elements` |  Search for multiple elements on the page, starting from the identified element.
-![Implemented](./docs/implemented.png "Implemented") | POST | `/session/:sessionId/element/:id/click` | Click on an element.
-![Not Yet Implemented](./docs/not_implemented.png "Not Yet Implemented") | POST | `/session/:sessionId/element/:id/submit` |  Submit a FORM element.
-![Implemented](./docs/implemented.png "Implemented") | GET | `/session/:sessionId/element/:id/text` |  Returns the visible text for the element.
+![impl] | POST | `/session/:sessionId/element/:id/click` | Click on an element.
+![not-yet] | POST | `/session/:sessionId/element/:id/submit` |  Submit a FORM element.
+![impl] | GET | `/session/:sessionId/element/:id/text` |  Returns the visible text for the element.
 ![Partially Implemented](./docs/partially_implemented.png "Does not support special characters") | POST | `/session/:sessionId/element/:id/value` | Send a sequence of key strokes to an element.
-![Not Yet Implemented](./docs/not_implemented.png "Not Yet Implemented") | POST | `/session/:sessionId/keys` |  Send a sequence of key strokes to the active element.
-![Not Yet Implemented](./docs/not_implemented.png "Not Yet Implemented") | GET | `/session/:sessionId/element/:id/name` |  Query for an element's tag name.
-![Implemented](./docs/implemented.png "Implemented") | POST | `/session/:sessionId/element/:id/clear` | Clear a TEXTAREA or text INPUT element's value.
-![Not Yet Implemented](./docs/not_implemented.png "Not Yet Implemented") | GET | `/session/:sessionId/element/:id/selected` |  Determine if an OPTION element, or an INPUT element of type checkbox or radiobutton is currently selected.
-![Not Yet Implemented](./docs/not_implemented.png "Not Yet Implemented") | GET | `/session/:sessionId/element/:id/enabled` | Determine if an element is currently enabled.
-![Implemented](./docs/implemented.png "Implemented") | GET | `/session/:sessionId/element/:id/attribute/:name` | Get the value of an element's attribute.
-![Not Yet Implemented](./docs/not_implemented.png "Not Yet Implemented") | GET | `/session/:sessionId/element/:id/equals/:other` | Test if two element IDs refer to the same DOM element.
-![Implemented](./docs/implemented.png "Implemented") | GET | `/session/:sessionId/element/:id/displayed` | Determine if an element is currently displayed.
-![Implemented](./docs/implemented.png "Implemented") | GET | `/session/:sessionId/element/:id/location` |  Determine an element's location on the page.
-![Implemented](./docs/implemented.png "Implemented") | GET | `/session/:sessionId/element/:id/location_in_view` |  Determine an element's location on the screen once it has been scrolled into view.
-![Implemented](./docs/implemented.png "Implemented") | GET | `/session/:sessionId/element/:id/size` |  Determine an element's size in pixels.
-![Not Yet Implemented](./docs/not_implemented.png "Not Yet Implemented") | GET | `/session/:sessionId/element/:id/css/:propertyName` | Query the value of an element's computed CSS property.
-![Not Yet Implemented](./docs/not_implemented.png "Not Yet Implemented") | GET | `/session/:sessionId/orientation` | Get the current browser orientation.
-![Not Yet Implemented](./docs/not_implemented.png "Not Yet Implemented") | POST | `/session/:sessionId/orientation` | Set the browser orientation.
-![Implemented](./docs/implemented.png "Implemented") | GET | `/session/:sessionId/alert_text` |  Gets the text of the currently displayed JavaScript alert(), confirm(), or prompt() dialog.
-![Implemented](./docs/implemented.png "Implemented") | POST | `/session/:sessionId/alert_text` |  Sends keystrokes to a JavaScript prompt() dialog.
-![Implemented](./docs/implemented.png "Implemented") | POST | `/session/:sessionId/accept_alert` |  Accepts the currently displayed alert dialog.
-![Implemented](./docs/implemented.png "Implemented") | POST | `/session/:sessionId/dismiss_alert` | Dismisses the currently displayed alert dialog.
-![Not Yet Implemented](./docs/not_implemented.png "Not Yet Implemented") | POST | `/session/:sessionId/moveto` |  Move the mouse by an offset of the specificed element.
-![Not Yet Implemented](./docs/not_implemented.png "Not Yet Implemented") | POST | `/session/:sessionId/click` | Click any mouse button (at the coordinates set by the last moveto command).
-![Not Yet Implemented](./docs/not_implemented.png "Not Yet Implemented") | POST | `/session/:sessionId/buttondown` |  Click and hold the left mouse button (at the coordinates set by the last moveto command).
-![Not Yet Implemented](./docs/not_implemented.png "Not Yet Implemented") | POST | `/session/:sessionId/buttonup` |  Releases the mouse button previously held (where the mouse is currently at).
-![Not Yet Implemented](./docs/not_implemented.png "Not Yet Implemented") | POST | `/session/:sessionId/doubleclick` | Double-clicks at the current mouse coordinates (set by moveto).
-![Not Yet Implemented](./docs/not_implemented.png "Not Yet Implemented") | POST | `/session/:sessionId/touch/click` | Single tap on the touch enabled device.
-![Not Yet Implemented](./docs/not_implemented.png "Not Yet Implemented") | POST | `/session/:sessionId/touch/down` |  Finger down on the screen.
-![Not Yet Implemented](./docs/not_implemented.png "Not Yet Implemented") | POST | `/session/:sessionId/touch/up` |  Finger up on the screen.
-![Not Yet Implemented](./docs/not_implemented.png "Not Yet Implemented") | POST | `session/:sessionId/touch/move` | Finger move on the screen.
-![Not Yet Implemented](./docs/not_implemented.png "Not Yet Implemented") | POST | `session/:sessionId/touch/scroll` | Scroll on the touch screen using finger based motion events.
-![Not Yet Implemented](./docs/not_implemented.png "Not Yet Implemented") | POST | `session/:sessionId/touch/scroll` | Scroll on the touch screen using finger based motion events.
-![Not Yet Implemented](./docs/not_implemented.png "Not Yet Implemented") | POST | `session/:sessionId/touch/doubleclick` |  Double tap on the touch screen using finger motion events.
-![Not Yet Implemented](./docs/not_implemented.png "Not Yet Implemented") | POST | `session/:sessionId/touch/longclick` |  Long press on the touch screen using finger motion events.
-![Not Yet Implemented](./docs/not_implemented.png "Not Yet Implemented") | POST | `session/:sessionId/touch/flick` |  Flick on the touch screen using finger motion events.
-![Not Yet Implemented](./docs/not_implemented.png "Not Yet Implemented") | POST | `session/:sessionId/touch/flick` |  Flick on the touch screen using finger motion events.
-![Implemented](./docs/implemented.png "Implemented") | GET | `/session/:sessionId/location` |  Get the current geo location.
-![Implemented](./docs/implemented.png "Implemented") | POST | `/session/:sessionId/location` |  Set the current geo location.
-![Implemented](./docs/implemented.png "Implemented") | GET | `/session/:sessionId/local_storage` | Get all keys of the storage.
-![Implemented](./docs/implemented.png "Implemented") | POST | `/session/:sessionId/local_storage` | Set the storage item for the given key.
-![Implemented](./docs/implemented.png "Implemented") | DELETE | `/session/:sessionId/local_storage` | Clear the storage.
-![Not Yet Implemented](./docs/not_implemented.png "Not Yet Implemented") | GET | `/session/:sessionId/local_storage/key/:key` |  Get the storage item for the given key.
-![Not Yet Implemented](./docs/not_implemented.png "Not Yet Implemented") | DELETE | `/session/:sessionId/local_storage/key/:key` |  Remove the storage item for the given key.
-![Not Yet Implemented](./docs/not_implemented.png "Not Yet Implemented") | GET | `/session/:sessionId/local_storage/size` |  Get the number of items in the storage.
-![Not Yet Implemented](./docs/not_implemented.png "Not Yet Implemented") | GET | `/session/:sessionId/session_storage` | Get all keys of the storage.
-![Not Yet Implemented](./docs/not_implemented.png "Not Yet Implemented") | POST | `/session/:sessionId/session_storage` | Set the storage item for the given key.
-![Not Yet Implemented](./docs/not_implemented.png "Not Yet Implemented") | DELETE | `/session/:sessionId/session_storage` | Clear the storage.
-![Not Yet Implemented](./docs/not_implemented.png "Not Yet Implemented") | GET | `/session/:sessionId/session_storage/key/:key` |  Get the storage item for the given key.
-![Not Yet Implemented](./docs/not_implemented.png "Not Yet Implemented") | DELETE | `/session/:sessionId/session_storage/key/:key` |  Remove the storage item for the given key.
-![Not Yet Implemented](./docs/not_implemented.png "Not Yet Implemented") | GET | `/session/:sessionId/session_storage/size` |  Get the number of items in the storage.
-![Not Yet Implemented](./docs/not_implemented.png "Not Yet Implemented") | POST | `/session/:sessionId/log` | Get the log for a given log type.
-![Not Yet Implemented](./docs/not_implemented.png "Not Yet Implemented") | GET | `/session/:sessionId/log/types` | Get available log types.
-![Not Yet Implemented](./docs/not_implemented.png "Not Yet Implemented") | GET | `/session/:sessionId/application_cache/status` |  Get the status of the html5 application cache.
+![not-yet] | POST | `/session/:sessionId/keys` |  Send a sequence of key strokes to the active element.
+![not-yet] | GET | `/session/:sessionId/element/:id/name` |  Query for an element's tag name.
+![impl] | POST | `/session/:sessionId/element/:id/clear` | Clear a TEXTAREA or text INPUT element's value.
+![not-yet] | GET | `/session/:sessionId/element/:id/selected` |  Determine if an OPTION element, or an INPUT element of type checkbox or radiobutton is currently selected.
+![not-yet] | GET | `/session/:sessionId/element/:id/enabled` | Determine if an element is currently enabled.
+![impl] | GET | `/session/:sessionId/element/:id/attribute/:name` | Get the value of an element's attribute.
+![not-yet] | GET | `/session/:sessionId/element/:id/equals/:other` | Test if two element IDs refer to the same DOM element.
+![impl] | GET | `/session/:sessionId/element/:id/displayed` | Determine if an element is currently displayed.
+![impl] | GET | `/session/:sessionId/element/:id/location` |  Determine an element's location on the page.
+![impl] | GET | `/session/:sessionId/element/:id/location_in_view` |  Determine an element's location on the screen once it has been scrolled into view.
+![impl] | GET | `/session/:sessionId/element/:id/size` |  Determine an element's size in pixels.
+![not-yet] | GET | `/session/:sessionId/element/:id/css/:propertyName` | Query the value of an element's computed CSS property.
+![not-yet] | GET | `/session/:sessionId/orientation` | Get the current browser orientation.
+![not-yet] | POST | `/session/:sessionId/orientation` | Set the browser orientation.
+![impl] | GET | `/session/:sessionId/alert_text` |  Gets the text of the currently displayed JavaScript alert(), confirm(), or prompt() dialog.
+![impl] | POST | `/session/:sessionId/alert_text` |  Sends keystrokes to a JavaScript prompt() dialog.
+![impl] | POST | `/session/:sessionId/accept_alert` |  Accepts the currently displayed alert dialog.
+![impl] | POST | `/session/:sessionId/dismiss_alert` | Dismisses the currently displayed alert dialog.
+![impl] | POST | `/session/:sessionId/moveto` |  Move the pointer by an offset of the specified element.
+![not-yet] | POST | `/session/:sessionId/click` | Click any pointer button (at the coordinates set by the last moveto command).
+![impl] | POST | `/session/:sessionId/buttondown` |  Click and hold the left pointer button (at the coordinates set by the last moveto command).
+![impl] | POST | `/session/:sessionId/buttonup` |  Releases the pointer button previously held (where the pointer is currently at).
+![not-yet] | POST | `/session/:sessionId/doubleclick` | Double-clicks at the current pointer coordinates (set by moveto).
+![not-yet] | POST | `/session/:sessionId/touch/click` | Single tap on the touch enabled device.
+![not-yet] | POST | `/session/:sessionId/touch/down` |  Finger down on the screen.
+![not-yet] | POST | `/session/:sessionId/touch/up` |  Finger up on the screen.
+![not-yet] | POST | `session/:sessionId/touch/move` | Finger move on the screen.
+![not-yet] | POST | `session/:sessionId/touch/scroll` | Scroll on the touch screen using finger based motion events.
+![not-yet] | POST | `session/:sessionId/touch/scroll` | Scroll on the touch screen using finger based motion events.
+![not-yet] | POST | `session/:sessionId/touch/doubleclick` |  Double tap on the touch screen using finger motion events.
+![not-yet] | POST | `session/:sessionId/touch/longclick` |  Long press on the touch screen using finger motion events.
+![not-yet] | POST | `session/:sessionId/touch/flick` |  Flick on the touch screen using finger motion events.
+![not-yet] | POST | `session/:sessionId/touch/flick` |  Flick on the touch screen using finger motion events.
+![impl] | GET | `/session/:sessionId/location` |  Get the current geo location.
+![impl] | POST | `/session/:sessionId/location` |  Set the current geo location.
+![impl] | GET | `/session/:sessionId/local_storage` | Get all keys of the storage.
+![impl] | POST | `/session/:sessionId/local_storage` | Set the storage item for the given key.
+![impl] | DELETE | `/session/:sessionId/local_storage` | Clear the storage.
+![not-yet] | GET | `/session/:sessionId/local_storage/key/:key` |  Get the storage item for the given key.
+![not-yet] | DELETE | `/session/:sessionId/local_storage/key/:key` |  Remove the storage item for the given key.
+![not-yet] | GET | `/session/:sessionId/local_storage/size` |  Get the number of items in the storage.
+![not-yet] | GET | `/session/:sessionId/session_storage` | Get all keys of the storage.
+![not-yet] | POST | `/session/:sessionId/session_storage` | Set the storage item for the given key.
+![not-yet] | DELETE | `/session/:sessionId/session_storage` | Clear the storage.
+![not-yet] | GET | `/session/:sessionId/session_storage/key/:key` |  Get the storage item for the given key.
+![not-yet] | DELETE | `/session/:sessionId/session_storage/key/:key` |  Remove the storage item for the given key.
+![not-yet] | GET | `/session/:sessionId/session_storage/size` |  Get the number of items in the storage.
+![not-yet] | POST | `/session/:sessionId/log` | Get the log for a given log type.
+![not-yet] | GET | `/session/:sessionId/log/types` | Get available log types.
+![not-yet] | GET | `/session/:sessionId/application_cache/status` |  Get the status of the html5 application cache.
+
+
+[impl]: ./docs/implemented.png "Implemented"
+[not-yet]: ./docs/not_implemented.png "Not Yet Implemented"

--- a/lib/element.js
+++ b/lib/element.js
@@ -152,6 +152,20 @@ module.exports = Element = (function() {
     this.http.post(this.root + "/clear");
   };
 
+  Element.prototype.movePointerRelativeTo = function(xOffset, yOffset) {
+    var opts;
+    opts = {
+      element: this.elementId
+    };
+    if (xOffset != null) {
+      opts.xoffset = xOffset;
+    }
+    if (yOffset != null) {
+      opts.yoffset = yOffset;
+    }
+    this.http.post('/moveto', opts);
+  };
+
   return Element;
 
 })();

--- a/lib/index.js
+++ b/lib/index.js
@@ -30,7 +30,7 @@ LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
 NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
 SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
-var WebDriver, assert, buildRequester, createAlertApi, createCookieApi, createDebugApi, createElementApi, createLocalStorageApi, createLocationApi, createNavigationApi, createPageApi, createSession, createWindowApi, extend, http, parseResponseData,
+var WebDriver, assert, buildRequester, createAlertApi, createCookieApi, createDebugApi, createElementApi, createLocalStorageApi, createLocationApi, createNavigationApi, createPageApi, createPointerApi, createSession, createWindowApi, extend, http, parseResponseData,
   slice = [].slice;
 
 assert = require('assertive');
@@ -49,17 +49,19 @@ createAlertApi = require('./alert_api');
 
 createCookieApi = require('./cookie_api');
 
+createDebugApi = require('./debug_api');
+
 createElementApi = require('./element_api');
 
-createLocationApi = require('./location_api');
-
 createLocalStorageApi = require('./local_storage_api');
+
+createLocationApi = require('./location_api');
 
 createNavigationApi = require('./navigation_api');
 
 createPageApi = require('./page_api');
 
-createDebugApi = require('./debug_api');
+createPointerApi = require('./pointer_api');
 
 createWindowApi = require('./window_api');
 
@@ -76,12 +78,13 @@ module.exports = WebDriver = (function() {
     this.http = http(request, serverUrl, sessionId);
     extend(this, createAlertApi(this.http));
     extend(this, createCookieApi(this.http));
+    extend(this, createDebugApi(this.http));
     extend(this, createElementApi(this.http));
-    extend(this, createLocationApi(this.http));
     extend(this, createLocalStorageApi(this.http));
+    extend(this, createLocationApi(this.http));
     extend(this, createNavigationApi(this.http));
     extend(this, createPageApi(this.http));
-    extend(this, createDebugApi(this.http));
+    extend(this, createPointerApi(this.http));
     extend(this, createWindowApi(this.http));
   }
 

--- a/lib/pointer_api.js
+++ b/lib/pointer_api.js
@@ -1,0 +1,52 @@
+
+/*
+Copyright (c) 2013, Groupon, Inc.
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions
+are met:
+
+Redistributions of source code must retain the above copyright notice,
+this list of conditions and the following disclaimer.
+
+Redistributions in binary form must reproduce the above copyright
+notice, this list of conditions and the following disclaimer in the
+documentation and/or other materials provided with the distribution.
+
+Neither the name of GROUPON nor the names of its contributors may be
+used to endorse or promote products derived from this software without
+specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS
+IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED
+TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A
+PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED
+TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+module.exports = function(http) {
+  return {
+    buttonDown: function(button) {
+      if (button == null) {
+        button = 0;
+      }
+      http.post('/buttondown', {
+        button: button
+      });
+    },
+    buttonUp: function(button) {
+      if (button == null) {
+        button = 0;
+      }
+      http.post('/buttonup', {
+        button: button
+      });
+    }
+  };
+};

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     }
   },
   "dependencies": {
-    "assertive": "^1.4.0",
+    "assertive": "^2.0.0",
     "bindings": "~1.2.1",
     "caseless": "~0.11.0",
     "coffee-script": "^1.10.0",
@@ -37,7 +37,6 @@
     "nan": "^2.0.9"
   },
   "devDependencies": {
-    "assertive": "^2.0.0",
     "mocha": "^2.0.0",
     "nlm": "^2.0.0",
     "nodemon": "^1.0.0"

--- a/src/element.coffee
+++ b/src/element.coffee
@@ -123,6 +123,13 @@ module.exports = class Element
     @http.post "#{@root}/clear"
     return
 
+  movePointerRelativeTo: (xOffset, yOffset) ->
+    opts = element: @elementId
+    opts.xoffset = xOffset if xOffset?
+    opts.yoffset = yOffset if yOffset?
+    @http.post '/moveto', opts
+    return
+
 elementOrNull = Element.elementOrNull = (create) ->
   try
     create()

--- a/src/index.coffee
+++ b/src/index.coffee
@@ -39,12 +39,13 @@ buildRequester = require './request'
 
 createAlertApi = require './alert_api'
 createCookieApi = require './cookie_api'
+createDebugApi = require './debug_api'
 createElementApi = require './element_api'
-createLocationApi = require './location_api'
 createLocalStorageApi = require './local_storage_api'
+createLocationApi = require './location_api'
 createNavigationApi = require './navigation_api'
 createPageApi = require './page_api'
-createDebugApi = require './debug_api'
+createPointerApi = require './pointer_api'
 createWindowApi = require './window_api'
 
 module.exports = class WebDriver
@@ -59,12 +60,13 @@ module.exports = class WebDriver
 
     extend this, createAlertApi(@http)
     extend this, createCookieApi(@http)
+    extend this, createDebugApi(@http)
     extend this, createElementApi(@http)
-    extend this, createLocationApi(@http)
     extend this, createLocalStorageApi(@http)
+    extend this, createLocationApi(@http)
     extend this, createNavigationApi(@http)
     extend this, createPageApi(@http)
-    extend this, createDebugApi(@http)
+    extend this, createPointerApi(@http)
     extend this, createWindowApi(@http)
 
   on: (event, callback) ->

--- a/src/pointer_api.coffee
+++ b/src/pointer_api.coffee
@@ -1,0 +1,39 @@
+###
+Copyright (c) 2013, Groupon, Inc.
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions
+are met:
+
+Redistributions of source code must retain the above copyright notice,
+this list of conditions and the following disclaimer.
+
+Redistributions in binary form must reproduce the above copyright
+notice, this list of conditions and the following disclaimer in the
+documentation and/or other materials provided with the distribution.
+
+Neither the name of GROUPON nor the names of its contributors may be
+used to endorse or promote products derived from this software without
+specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS
+IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED
+TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A
+PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED
+TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+###
+module.exports = (http) ->
+  buttonDown: (button=0) ->
+    http.post '/buttondown', { button }
+    return
+
+  buttonUp: (button=0) ->
+    http.post '/buttonup', { button }
+    return


### PR DESCRIPTION
These three ops let us simulate drag-and-drop.  The modern equivalent
would be "actions", but AFAICT this isn't fully implemented in webdrivers
yet.

* add toplevel `buttonDown()` and `buttonUp()` functions
* add `Element#movePointerRelativeTo()` method
* DRY the docs a bit
* fix duplicate `assertive` include