### PR TITLE
change supported node versions to 4 and 6

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: node_js
 node_js:
-  - '0.10'
   - '4'
+  - '6'
 before_install:
   - npm install -g npm@latest-2
 before_deploy:

--- a/README.md
+++ b/README.md
@@ -8,8 +8,6 @@ Keep up to date with changes
 by checking the
 [releases](https://github.com/groupon-testium/webdriver-http-sync/releases).
 
-Tested on node.js 0.10.* and io.js.
-
 ## Install
 
 On Ubuntu, you need to make sure you have libcurl installed.


### PR DESCRIPTION
We should support whatever LTS versions that Node.js still maintains.